### PR TITLE
Replaced System.out.println() with LOG.trace()

### DIFF
--- a/src/main/java/net/dv8tion/jda/ConnectionManager.java
+++ b/src/main/java/net/dv8tion/jda/ConnectionManager.java
@@ -175,7 +175,7 @@ public class ConnectionManager
 
                         Map.Entry<String, MutablePair<Long, String>> requestEntry = getNextAudioConnectRequest();
 
-                        System.out.println(requestEntry);
+                        LOG.trace(requestEntry);
                         if (requestEntry != null)
                         {
                             String guildId = requestEntry.getKey();
@@ -191,7 +191,7 @@ public class ConnectionManager
                                             .put("self_deaf", audioManager.isSelfDeafened())
                                     );
                             needRatelimit = !send(audioConnectPacket.toString());
-                            System.out.println(needRatelimit);
+                            LOG.trace(needRatelimit);
                             if (!needRatelimit)
                             {
                                 //If we didn't get RateLimited, Next allowed connect request will be 2 seconds from now


### PR DESCRIPTION
```
null
null
null
null
null
null
null
null
null
null
null
null
null
null
null
null
null
null
null
null
null
null
null
null
null
null
null
null
null
null
null
null
null
null
null
```

Alternatively, I can just remove it altogether. 