### PR TITLE
Provide guild IDs in CoreClient#voiceChannelExists() and CoreClient#hasPermissionInChannel()

### DIFF
--- a/src/main/java/net/dv8tion/jda/ConnectionManager.java
+++ b/src/main/java/net/dv8tion/jda/ConnectionManager.java
@@ -93,7 +93,7 @@ public class ConnectionManager
                         continue;
                     }
 
-                    if (!core.getClient().voiceChannelExists(channelId))
+                    if (!core.getClient().voiceChannelExists(guildId, channelId))
                     {
                         it.remove();
                         if (listener != null)
@@ -101,7 +101,7 @@ public class ConnectionManager
                         continue;
                     }
 
-                    if (!core.getClient().hasPermissionInChannel(channelId, 1 << 20)) //VOICE_CONNECT
+                    if (!core.getClient().hasPermissionInChannel(guildId, channelId, 1 << 20)) //VOICE_CONNECT
                     {
                         it.remove();
                         if (listener != null)

--- a/src/main/java/net/dv8tion/jda/CoreClient.java
+++ b/src/main/java/net/dv8tion/jda/CoreClient.java
@@ -21,6 +21,6 @@ public interface CoreClient
     void sendWS(String message);
     boolean isConnected();
     boolean inGuild(String guildId);
-    boolean voiceChannelExists(String channelId);
-    boolean hasPermissionInChannel(String channelId, long permission);
+    boolean voiceChannelExists(String guildId, String channelId);
+    boolean hasPermissionInChannel(String guildId, String channelId, long permission);
 }


### PR DESCRIPTION
This small breaking change allows for much easier implementation of CoreClient.