### PR TITLE
Replace audio send factory static abuse with nonstatic justice

### DIFF
--- a/src/main/java/net/dv8tion/jda/Core.java
+++ b/src/main/java/net/dv8tion/jda/Core.java
@@ -17,6 +17,8 @@
 package net.dv8tion.jda;
 
 import net.dv8tion.jda.audio.AudioWebSocket;
+import net.dv8tion.jda.audio.factory.DefaultSendFactory;
+import net.dv8tion.jda.audio.factory.IAudioSendFactory;
 import net.dv8tion.jda.handle.VoiceServerUpdateHandler;
 import net.dv8tion.jda.manager.AudioManager;
 import net.dv8tion.jda.utils.SimpleLog;
@@ -35,6 +37,7 @@ public class Core
     private final VoiceServerUpdateHandler vsuHandler;
     private final String userId;
     private final CoreClient coreClient;
+    private final IAudioSendFactory sendFactory;
 
     /**
      * Creates a new Core instance. You should probably have one of these for each shard, but you do you.
@@ -44,11 +47,24 @@ public class Core
      */
     public Core(String userId, CoreClient coreClient)
     {
+        this(userId, coreClient, new DefaultSendFactory());
+    }
+
+    /**
+     * Creates a new Core instance. You should probably have one of these for each shard, but you do you.
+     *
+     * @param userId The UserId of the bot.
+     * @param coreClient used to insert required functionality to connect Core to the MainWS
+     * @param coreClient the {@link net.dv8tion.jda.audio.factory.IAudioSendFactory} to use.
+     */
+    public Core(String userId, CoreClient coreClient, IAudioSendFactory sendFactory)
+    {
         this.userId = userId;
         this.coreClient = coreClient;
         this.connManager = new ConnectionManager(this);
         this.vsuHandler = new VoiceServerUpdateHandler(this);
         this.audioKeepAlivePool = new ScheduledThreadPoolExecutor(1, new AudioWebSocket.KeepAliveThreadFactory());
+        this.sendFactory = sendFactory;
     }
 
     // ==================================================================
@@ -78,6 +94,11 @@ public class Core
         }
 
         return manager;
+    }
+
+    public IAudioSendFactory getSendFactory()
+    {
+        return sendFactory;
     }
 
     // ====================================================================

--- a/src/main/java/net/dv8tion/jda/audio/AudioConnection.java
+++ b/src/main/java/net/dv8tion/jda/audio/AudioConnection.java
@@ -19,7 +19,6 @@ package net.dv8tion.jda.audio;
 import com.sun.jna.ptr.PointerByReference;
 import gnu.trove.map.TIntObjectMap;
 import gnu.trove.map.hash.TIntObjectHashMap;
-import net.dv8tion.jda.audio.factory.DefaultSendFactory;
 import net.dv8tion.jda.audio.factory.IAudioSendFactory;
 import net.dv8tion.jda.audio.factory.IAudioSendSystem;
 import net.dv8tion.jda.audio.factory.IPacketProvider;
@@ -53,7 +52,7 @@ public class AudioConnection
     public static final int OPUS_CHANNEL_COUNT = 2;     //We want to use stereo. If the audio given is mono, the encoder promotes it
                                                         // to Left and Right mono (stereo that is the same on both sides)
 
-    public static IAudioSendFactory sendFactory = new DefaultSendFactory();
+    public final IAudioSendFactory sendFactory;
 
     private final TIntObjectMap<String> ssrcMap = new TIntObjectHashMap();
     private final TIntObjectMap<Decoder> opusDecoders = new TIntObjectHashMap<>();
@@ -79,21 +78,14 @@ public class AudioConnection
     boolean sentSilenceOnConnect = false;
     private final byte[] silenceBytes = new byte[] {(byte)0xF8, (byte)0xFF, (byte)0xFE};
 
-    public AudioConnection(AudioWebSocket webSocket, String channelId)
+    public AudioConnection(AudioWebSocket webSocket, String channelId, IAudioSendFactory sendFactory)
     {
         this.channelId = channelId;
         this.webSocket = webSocket;
+        this.sendFactory = sendFactory;
         this.webSocket.audioConnection = this;
 
         this.threadIdentifier = /**api.getIdentifierString() + */ " AudioConnection ChannelId: " + channelId;
-    }
-
-    public static void setAudioSendFactory(IAudioSendFactory factory)
-    {
-        if (sendFactory == null)
-            throw new IllegalArgumentException("Send factory is null!");
-
-        sendFactory = factory;
     }
 
     public void ready(long timeout)

--- a/src/main/java/net/dv8tion/jda/handle/VoiceServerUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/VoiceServerUpdateHandler.java
@@ -69,7 +69,7 @@ public class VoiceServerUpdateHandler
             }
 
             AudioWebSocket socket = new AudioWebSocket(audioManager.getListenerProxy(), endpoint, core, guildId, sessionId, token, audioManager.isAutoReconnect());
-            AudioConnection connection = new AudioConnection(socket, audioManager.getQueuedAudioConnectionId());
+            AudioConnection connection = new AudioConnection(socket, audioManager.getQueuedAudioConnectionId(), core.getSendFactory());
             audioManager.setAudioConnection(connection);
             socket.startConnection();
 


### PR DESCRIPTION
Currently, the audio send factory is static in AudioConnection. NAS doesn't scale well beyond 600 audio connections from the same factory. This fixes that problem.